### PR TITLE
Fix nextjs build type error

### DIFF
--- a/components/pages/GoalsDashboard.tsx
+++ b/components/pages/GoalsDashboard.tsx
@@ -366,7 +366,7 @@ export default function GoalsDashboard() {
                           : 'border-gray-200 bg-white text-gray-600 hover:border-emerald-200 hover:text-emerald-700'
                       }`}
                     >
-                      {filter.id === 'all' ? 'All' : `${filter.emoji} ${filter.label}`}
+                      {filter.id === 'all' ? 'All' : `${'emoji' in filter ? filter.emoji + ' ' : ''}${filter.label}`}
                     </button>
                   );
                 })}


### PR DESCRIPTION
Fixes a TypeScript error by safely accessing the `emoji` property in `GoalsDashboard`.

The build failed because the `filter` variable was a union type, and one of its possible types (`{ id: string; label: string; }`) did not include an `emoji` property, causing a compilation error when `filter.emoji` was accessed unconditionally. A type guard was added to check for the `emoji` property before attempting to use it.

---
<a href="https://cursor.com/background-agent?bcId=bc-08b67b9f-8846-4906-b728-c0cb83818605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08b67b9f-8846-4906-b728-c0cb83818605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

