### PR TITLE
Rename dashboard to home

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -180,7 +180,7 @@ export default function RootLayout({
                 
                   <nav className="flex space-x-8">
                     <Link href="/" className="text-gray-700 hover:text-green-600 transition-colors font-medium">
-                      Dashboard
+                      Home
                     </Link>
                     <Link href="/settings" className="text-gray-700 hover:text-green-600 transition-colors font-medium">
                       Settings
@@ -209,11 +209,11 @@ export default function RootLayout({
               
               {/* Mobile Navigation */}
                 <div className="flex justify-around">
-                  <Link href="/" className="flex flex-col items-center py-2 px-3 text-gray-600 hover:text-green-600 transition-colors" aria-label="Go to Dashboard">
+                  <Link href="/" className="flex flex-col items-center py-2 px-3 text-gray-600 hover:text-green-600 transition-colors" aria-label="Go to Home">
                     <svg className="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                     </svg>
-                    <span className="text-xs">Dashboard</span>
+                    <span className="text-xs">Home</span>
                   </Link>
                   <Link href="/settings" className="flex flex-col items-center py-2 px-3 text-gray-600 hover:text-green-600 transition-colors" aria-label="Go to Settings">
                     <svg className="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -255,7 +255,7 @@ export default function RootLayout({
                   <h4 className="text-md font-semibold text-gray-800 mb-4">Quick Links</h4>
                     <div className="space-y-2">
                       <Link href="/" className="block text-sm text-gray-600 hover:text-green-600 transition-colors">
-                        Dashboard
+                        Home
                       </Link>
                       <Link href="/settings" className="block text-sm text-gray-600 hover:text-green-600 transition-colors">
                         Settings

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -37,7 +37,7 @@ export default function NotFound() {
             href="/"
             className="block w-full py-3 px-6 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors font-medium"
           >
-            Return to Dashboard
+            Return to Home
           </Link>
           <div className="flex gap-3">
             <Link 
@@ -50,7 +50,7 @@ export default function NotFound() {
                 href="/"
                 className="flex-1 py-2 px-4 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm"
               >
-                Goals Dashboard
+                Goals
               </Link>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import GoalsDashboard from '@/components/pages/GoalsDashboard';
 
-export default function DashboardPage() {
+export default function HomePage() {
   return <GoalsDashboard />;
 }

--- a/components/pages/GoalsDashboard.tsx
+++ b/components/pages/GoalsDashboard.tsx
@@ -231,7 +231,7 @@ export default function GoalsDashboard() {
         <div className="relative z-10 space-y-8 p-6 md:p-10">
           <div className="space-y-3">
             <p className="text-sm uppercase tracking-[0.3em] text-white/70">
-              Goals Dashboard
+              Goals
             </p>
             <h1 className="text-3xl font-bold md:text-4xl">
               Align your intentions with meaningful action


### PR DESCRIPTION
Rename all user-facing "Dashboard" references to "Home" for improved clarity and consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a45436e-0f2e-4d2f-8c69-25ed1ec4e35a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a45436e-0f2e-4d2f-8c69-25ed1ec4e35a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

