### PR TITLE
Correct surah text display order

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -231,7 +231,7 @@ export default function HomePage() {
 
         {/* Goals Grid */}
         {goals.length > 0 && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <AnimatePresence>
               {goals.map((goal) => {
                 const guidance = guidanceMap[goal.id]

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -326,9 +326,14 @@ export default function HomePage() {
                                     <div key={idx} className="space-y-3">
                                       {/* Surah reference */}
                                       <div className="flex items-center justify-between">
-                                        <span className="text-xs font-medium text-emerald-700 bg-emerald-100 px-2 py-1 rounded-full">
+                                        <a
+                                          href={`https://quran.com/${match.verse.surah_number}/${match.verse.ayah}`}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          className="text-xs font-medium text-emerald-700 bg-emerald-100 px-2 py-1 rounded-full hover:bg-emerald-200 transition-colors"
+                                        >
                                           {match.verse.surah} ({match.verse.surah_number}:{match.verse.ayah})
-                                        </span>
+                                        </a>
                                         
                                         {/* Audio button */}
                                         {match.verse.audio && (

--- a/lib/quran-engine.ts
+++ b/lib/quran-engine.ts
@@ -259,7 +259,7 @@ class QuranEngine {
         .map(apiVerse => ({
           apiVerse,
           relevanceScore: this.calculateRelevanceScore(goal, { 
-            text_en: apiVerse.translation || '', 
+            text_en: apiVerse.translation || apiVerse.text || '', 
             reflection: '' 
           } as any)
         }))
@@ -269,26 +269,38 @@ class QuranEngine {
       console.log('Top results by relevance:', sortedResults.map(r => ({ 
         verse: r.apiVerse.number, 
         score: r.relevanceScore,
-        text: r.apiVerse.translation?.substring(0, 100) + '...'
+        text: (r.apiVerse.translation || r.apiVerse.text)?.substring(0, 100) + '...'
       })));
       
       for (const { apiVerse } of sortedResults.slice(0, 1)) { // Show only 1 verse initially
-        const surahMetadata = await this.buildSurahMetadata(apiVerse);
-        const quranVerse = await this.convertAPIVerseToQuranVerse({
-          verse: apiVerse,
-          surah: surahMetadata,
-          theme,
-          context: `Guidance for: ${goal}`
-        });
+        // Fetch full verse data with both Arabic and English text
+        // Search results only contain one language, so we need the complete verse
+        const surahNum = apiVerse.surahNumber || apiVerse.surah?.number;
+        const verseNum = apiVerse.numberInSurah;
+        
+        if (surahNum && verseNum) {
+          try {
+            const fullVerse = await quranAPI.getVerse(surahNum, verseNum);
+            const surahMetadata = await this.buildSurahMetadata(fullVerse);
+            const quranVerse = await this.convertAPIVerseToQuranVerse({
+              verse: fullVerse,
+              surah: surahMetadata,
+              theme,
+              context: `Guidance for: ${goal}`
+            });
 
-        if (quranVerse) {
-          matches.push({
-            verse: quranVerse,
-            relevanceScore: this.calculateRelevanceScore(goal, quranVerse),
-            practicalSteps: this.generatePracticalSteps(theme, goal),
-            duaRecommendation: DUA_RECOMMENDATIONS[theme],
-            relatedHabits: this.getRelatedHabits(theme)
-          });
+            if (quranVerse) {
+              matches.push({
+                verse: quranVerse,
+                relevanceScore: this.calculateRelevanceScore(goal, quranVerse),
+                practicalSteps: this.generatePracticalSteps(theme, goal),
+                duaRecommendation: DUA_RECOMMENDATIONS[theme],
+                relatedHabits: this.getRelatedHabits(theme)
+              });
+            }
+          } catch (error) {
+            console.error('Error fetching full verse data:', error);
+          }
         }
       }
 
@@ -358,7 +370,7 @@ class QuranEngine {
         .map(apiVerse => ({
           apiVerse,
           relevanceScore: this.calculateRelevanceScore(goal, { 
-            text_en: apiVerse.translation || '', 
+            text_en: apiVerse.translation || apiVerse.text || '', 
             reflection: '' 
           } as any)
         }))
@@ -368,29 +380,41 @@ class QuranEngine {
       console.log('Additional results by relevance:', sortedResults.map(r => ({ 
         verse: r.apiVerse.number, 
         score: r.relevanceScore,
-        text: r.apiVerse.translation?.substring(0, 100) + '...'
+        text: (r.apiVerse.translation || r.apiVerse.text)?.substring(0, 100) + '...'
       })));
 
       // Convert API results to goal matches
       const matches: GoalMatchResult[] = [];
       
       for (const { apiVerse } of sortedResults) {
-        const surahMetadata = await this.buildSurahMetadata(apiVerse);
-        const quranVerse = await this.convertAPIVerseToQuranVerse({
-          verse: apiVerse,
-          surah: surahMetadata,
-          theme,
-          context: `Additional guidance for: ${goal}`
-        });
+        // Fetch full verse data with both Arabic and English text
+        // Search results only contain one language, so we need the complete verse
+        const surahNum = apiVerse.surahNumber || apiVerse.surah?.number;
+        const verseNum = apiVerse.numberInSurah;
+        
+        if (surahNum && verseNum) {
+          try {
+            const fullVerse = await quranAPI.getVerse(surahNum, verseNum);
+            const surahMetadata = await this.buildSurahMetadata(fullVerse);
+            const quranVerse = await this.convertAPIVerseToQuranVerse({
+              verse: fullVerse,
+              surah: surahMetadata,
+              theme,
+              context: `Additional guidance for: ${goal}`
+            });
 
-        if (quranVerse) {
-          matches.push({
-            verse: quranVerse,
-            relevanceScore: this.calculateRelevanceScore(goal, quranVerse),
-            practicalSteps: this.generatePracticalSteps(theme, goal),
-            duaRecommendation: DUA_RECOMMENDATIONS[theme],
-            relatedHabits: this.getRelatedHabits(theme)
-          });
+            if (quranVerse) {
+              matches.push({
+                verse: quranVerse,
+                relevanceScore: this.calculateRelevanceScore(goal, quranVerse),
+                practicalSteps: this.generatePracticalSteps(theme, goal),
+                duaRecommendation: DUA_RECOMMENDATIONS[theme],
+                relatedHabits: this.getRelatedHabits(theme)
+              });
+            }
+          } catch (error) {
+            console.error('Error fetching full verse data:', error);
+          }
         }
       }
 


### PR DESCRIPTION
Fixes surah display to show Arabic then English and changes goals grid to 2 columns.

Previously, when searching in English, the `searchVerses` function returned English text in both `text` and `translation` fields. This led to `verse.text` (which was English) being incorrectly mapped to `text_ar` (Arabic). The fix involves fetching the complete verse data (containing both Arabic and English) after initial search results to ensure proper language display.

---
<a href="https://cursor.com/background-agent?bcId=bc-968c4270-ed7b-4c54-93fe-776dd8e20168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-968c4270-ed7b-4c54-93fe-776dd8e20168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

