### PR TITLE
Debug mobile styling issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,10 +33,10 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'", // Note: Next.js requires unsafe-inline for now
-              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-              "font-src 'self' https://fonts.gstatic.com",
-              "img-src 'self' data: https:",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'", // Next.js requires unsafe-inline and unsafe-eval for hydration
+              "style-src 'self' 'unsafe-inline' blob: data: https://fonts.googleapis.com",
+              "font-src 'self' data: https://fonts.gstatic.com",
+              "img-src 'self' data: blob: https:",
               "media-src 'self' https://cdn.alquran.cloud https://cdn.islamic.network",
               "connect-src 'self' https://api.alquran.cloud https://cdn.alquran.cloud https://cdn.islamic.network",
               "frame-ancestors 'none'",

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,8 +4,8 @@
  * Author: Karim Osman (https://kar.im)
  */
 
-const CACHE_NAME = 'quranlife-v1';
-const STATIC_CACHE = 'quranlife-static-v1';
+const CACHE_NAME = 'quranlife-v2';
+const STATIC_CACHE = 'quranlife-static-v2';
 
 // Assets to cache for offline use
 const CACHE_ASSETS = [
@@ -70,36 +70,52 @@ self.addEventListener('fetch', (event) => {
   // Skip chrome-extension and other non-http requests
   if (!event.request.url.startsWith('http')) return;
 
+  const url = new URL(event.request.url);
+
+  // For Next.js static assets (CSS, JS with hashes), use network-first
+  // These are immutable and have unique hashes, so caching is safe
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          if (response.status === 200) {
+            const responseClone = response.clone();
+            caches.open(STATIC_CACHE)
+              .then(cache => cache.put(event.request, responseClone));
+          }
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // For navigation requests (HTML pages), always go network-first
+  // Don't cache HTML to avoid serving stale pages without proper CSS/JS
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .catch(() => {
+          // Offline fallback - serve cached page or offline page
+          return caches.match(event.request)
+            .then(cached => cached || caches.match('/'))
+            .then(cached => cached || new Response(
+              '<html><body><h1>QuranLife - Offline</h1><p>You are currently offline. Please check your connection and try again.</p></body></html>',
+              { headers: { 'Content-Type': 'text/html' } }
+            ));
+        })
+    );
+    return;
+  }
+
+  // For other static assets, try cache first, then network
   event.respondWith(
     caches.match(event.request)
       .then(cachedResponse => {
-        // Return cached version if available
         if (cachedResponse) {
           return cachedResponse;
         }
 
-        // For navigation requests (pages), try network first, fallback to cache
-        if (event.request.mode === 'navigate') {
-          return fetch(event.request)
-            .then(response => {
-              // Cache successful responses
-              if (response.status === 200) {
-                const responseClone = response.clone();
-                caches.open(CACHE_NAME)
-                  .then(cache => cache.put(event.request, responseClone));
-              }
-              return response;
-            })
-            .catch(() => {
-              // Offline fallback - serve cached page or offline page
-              return caches.match('/') || new Response(
-                '<html><body><h1>QuranLife - Offline</h1><p>You are currently offline. Please check your connection and try again.</p></body></html>',
-                { headers: { 'Content-Type': 'text/html' } }
-              );
-            });
-        }
-
-        // For other requests, try network first
         return fetch(event.request)
           .then(response => {
             // Cache successful responses for static assets
@@ -107,7 +123,10 @@ self.addEventListener('fetch', (event) => {
                 (event.request.url.includes('.json') || 
                  event.request.url.includes('.js') || 
                  event.request.url.includes('.css') ||
-                 event.request.url.includes('.svg'))) {
+                 event.request.url.includes('.svg') ||
+                 event.request.url.includes('.png') ||
+                 event.request.url.includes('.woff') ||
+                 event.request.url.includes('.woff2'))) {
               const responseClone = response.clone();
               caches.open(STATIC_CACHE)
                 .then(cache => cache.put(event.request, responseClone));


### PR DESCRIPTION
Fix missing styling on mobile by updating the Content-Security-Policy and improving service worker caching strategy.

The original Content-Security-Policy was too restrictive, blocking Next.js's dynamic CSS injection (blob/data URLs) and hydration scripts (`unsafe-eval`), which mobile browsers enforce more strictly. Additionally, the service worker's cache-first strategy for HTML and `/_next/static/` assets led to stale pages being served without their corresponding updated CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a5cec68-dc7b-4cf9-8edf-e0a16c453be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a5cec68-dc7b-4cf9-8edf-e0a16c453be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

